### PR TITLE
Install deps necessary to add ppas on older lts.

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -22,6 +22,8 @@ case $ID in
 				sudo apt-get install -y wiregarden wireguard-tools libnss-wiregarden
 				;;
 			16.04|18.04)
+				sudo apt-get update
+				sudo apt-get install -y software-properties-common
 				sudo add-apt-repository -y ppa:wireguard/wireguard
 				sudo apt-get update
 				sudo apt-get install -y wiregarden wireguard wireguard-tools libnss-wiregarden


### PR DESCRIPTION
Some images don't come with software-properties-common preinstalled. Not
sure how common that is, but it's at least an issue for LXD so might as
well avoid that hangup.