### PR TITLE
Fix watcher client, ensuring watches, service install.

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -70,7 +70,7 @@ func TestJoinApply(t *testing.T) {
 	c.Assert(ifaceLog.Log.Operation, qt.Equals, store.OpJoinDevice)
 	c.Assert(ifaceLog.Log.Dirty, qt.Equals, true)
 
-	err = a.ApplyInterfaceChanges(iface)
+	err = a.ApplyInterfaceChanges(ctx, iface)
 	c.Assert(err, qt.IsNil)
 	ifaceLog, err = st.LastLogByDevice("test-device", "test-net")
 	c.Assert(err, qt.IsNil)
@@ -148,7 +148,7 @@ func TestJoinRefreshDepart(t *testing.T) {
 	c.Assert(ifaceLogRefresh.Log.State, qt.Equals, store.StateInterfaceUp)
 	c.Assert(ifaceLogRefresh.Log.Dirty, qt.IsTrue)
 
-	err = a.ApplyInterfaceChanges(&ifaceLogRefresh.Interface)
+	err = a.ApplyInterfaceChanges(ctx, &ifaceLogRefresh.Interface)
 	c.Assert(err, qt.IsNil)
 
 	// Now depart device
@@ -160,7 +160,7 @@ func TestJoinRefreshDepart(t *testing.T) {
 	c.Assert(ifaceLogDelete.Log.Operation, qt.Equals, store.OpDeleteDevice)
 	c.Assert(ifaceLogDelete.Log.State, qt.Equals, store.StateInterfaceDeparted)
 	c.Assert(ifaceLogDelete.Log.Dirty, qt.IsTrue)
-	err = a.ApplyInterfaceChanges(iface)
+	err = a.ApplyInterfaceChanges(ctx, iface)
 	c.Assert(err, qt.IsNil)
 	lastLogDown, err := st.LastLogByDevice("test-device", "test-net")
 	c.Assert(err, qt.IsNil)
@@ -212,7 +212,7 @@ func TestJoinRefreshRevoked(t *testing.T) {
 	c.Assert(ifaceLogRefresh.Log.State, qt.Equals, store.StateInterfaceRevoked)
 	c.Assert(ifaceLogRefresh.Log.Dirty, qt.IsTrue)
 
-	err = a.ApplyInterfaceChanges(&ifaceLogRefresh.Interface)
+	err = a.ApplyInterfaceChanges(ctx, &ifaceLogRefresh.Interface)
 	c.Assert(err, qt.IsNil)
 
 	lastLog, err := st.LastLog(iface)

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -130,6 +130,11 @@ func (d *Watcher) ensureWatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	zapctx.Debug(ctx, "ensure watch", zap.Int64("id", id))
+	if _, ok := d.watchers[id]; ok {
+		zapctx.Debug(ctx, "already watching", zap.Int64("id", id))
+		return
+	}
+
 	iface, err := d.agent.Interface(id)
 	if err != nil {
 		zapctx.Debug(ctx, "failed to look up interface", zap.Int64("id", id), zap.Error(err))
@@ -217,7 +222,7 @@ func (d *Watcher) watchInterfaceEvents(ctx context.Context, cancel func(), iface
 					zap.String("network", iface.Network.Name))
 				return backoff.Permanent(errors.WithStack(err))
 			}
-			err = d.agent.ApplyInterfaceChanges(iface)
+			err = d.agent.ApplyInterfaceChanges(ctx, iface)
 			if err != nil {
 				return errors.WithStack(err)
 			}


### PR DESCRIPTION
Watcher client instantiated in agent with the constructor that sets up a
custom unix socket dialer, so it can actually connect now.

Agent now ensures/deletes watches on respective state changes, ensuring
a watch when interface goes up, deleting when it goes down.

Systemd service command is set based on the executable path of
wiregarden. postinstall does a restart, which should handle upgrades
better.