### PR TITLE
Ensure interface state has been applied to devices

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -560,6 +560,11 @@ func (a *Agent) ApplyInterfaceChanges(ctx context.Context, iface *store.Interfac
 	return nil
 }
 
+func (a *Agent) EnsureInterfaceState(iface *store.Interface, log *store.InterfaceLog) error {
+	_, err := a.applyInterfaceChanges(iface, log)
+	return errors.WithStack(err)
+}
+
 func (a *Agent) applyInterfaceChanges(iface *store.Interface, lastLog *store.InterfaceLog) (*store.InterfaceLog, error) {
 	switch lastLog.State {
 	case store.StateInterfaceJoined, store.StateInterfaceUp:

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -83,6 +83,11 @@ func (d *Watcher) Start(ctx context.Context) error {
 		if ifaces[i].Log.State == store.StateInterfaceDown {
 			continue
 		}
+		err := d.agent.EnsureInterfaceState(&ifaces[i].Interface, &ifaces[i].Log)
+		if err != nil {
+			zapctx.Error(ctx, "failed to ensure interface state",
+				zap.String("interface", ifaces[i].Interface.Name()), zap.Error(err))
+		}
 		wCtx, wCancel := context.WithCancel(ctx)
 		go d.watchInterfaceEvents(wCtx, wCancel, &ifaces[i].Interface)
 		d.watchers[ifaces[i].Id] = wCancel


### PR DESCRIPTION
on daemon startup. This basically makes wiregarden.service behave like a
dynamic wiregarden-aware wg-quick.service.