### PR TITLE
Improve status. Add rpm packaging.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,21 @@ dist/wiregarden:
 	-mkdir -p dist
 	go build -ldflags="-X github.com/wiregarden-io/wiregarden/cli.version=$(VERSION)" -a -o dist/wiregarden .
 
-deb:
+deb: dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).deb
+
+dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).deb:
 	VERSION="$(VERSION)" HERE=/pkg envsubst < .nfpm.yml.tmpl > .nfpm.yml
 	docker run -u $(shell id -u) --rm \
 		-v $(shell pwd):/pkg \
 		goreleaser/nfpm pkg --config /pkg/.nfpm.yml --target /pkg/dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).deb
+
+rpm: dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).rpm
+
+dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).rpm:
+	VERSION="$(VERSION)" HERE=/pkg envsubst < .nfpm.yml.tmpl > .nfpm.yml
+	docker run -u $(shell id -u) --rm \
+		-v $(shell pwd):/pkg \
+		goreleaser/nfpm pkg --config /pkg/.nfpm.yml --target /pkg/dist/wiregarden_$(VERSION)_$(GOOS)_$(GOARCH).rpm
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Sorting interfaces and peers in status.
Printing qualfied peer names that work w/nss-wiregarden.
Only show IP address of peers for copypasteability.

Add RPM packaging because why not.