### PR TITLE
Only consider devices as "revoked" on a 410 Gone response.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -373,7 +373,7 @@ func (a *Agent) RefreshInterface(ctx context.Context, iface *store.InterfaceWith
 		Endpoint: endpoint,
 	})
 	if err != nil {
-		if errors.Is(err, api.ErrApiForbidden) {
+		if errors.Is(err, api.ErrApiRevoked) {
 			return a.revokedInterface(ctx, iface)
 		}
 		return nil, errors.WithStack(err)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -189,7 +189,7 @@ func TestJoinRefreshRevoked(t *testing.T) {
 			Peers: []api.Device{},
 			Token: []byte("device-token"),
 		},
-		refreshErr: api.ErrApiForbidden,
+		refreshErr: api.ErrApiRevoked,
 	}, &mockNetworkManager{})
 	ctx := testContext()
 	iface, err := a.JoinDevice(ctx, "test-device", "test-net", "")

--- a/api/client.go
+++ b/api/client.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,10 +37,11 @@ type Client struct {
 }
 
 var (
-	ErrApiServer           = errors.New("api server error")
-	ErrApiClient           = errors.New("api client error")
-	ErrApiForbidden        = errors.New("api client forbidden")
-	ErrApiInvalidResponse  = errors.New("api server gave an invalid response")
+	ErrApiServer           = fmt.Errorf("api server error")
+	ErrApiClient           = fmt.Errorf("api client error")
+	ErrApiForbidden        = fmt.Errorf("api client forbidden")
+	ErrApiRevoked          = fmt.Errorf("api client revoked")
+	ErrApiInvalidResponse  = fmt.Errorf("api server gave an invalid response")
 	ErrDeviceAlreadyJoined = errors.Wrap(ErrApiClient, "device already joined")
 )
 
@@ -92,6 +94,8 @@ func (c *Client) Response(resp *http.Response, v interface{}) error {
 			// It's not you it's me
 			if resp.StatusCode == 403 {
 				return errors.Wrapf(ErrApiForbidden, "request failed: HTTP %d: %s", resp.StatusCode, string(respContents))
+			} else if resp.StatusCode == 410 {
+				return errors.Wrapf(ErrApiRevoked, "request failed: HTTP %d: %s", resp.StatusCode, string(respContents))
 			} else {
 				return errors.Wrapf(ErrApiClient, "request failed: HTTP %d: %s", resp.StatusCode, string(respContents))
 			}


### PR DESCRIPTION
Fixes #30 